### PR TITLE
Fix automated CI tests on Windows environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: Revert these lines if tests succeed.
+        # python-version: ["3.10", "3.11", "3.12"]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        # NOTE: Test only Python 3.10 on windows environment during pull request.
+        os: [windows-latest]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -30,13 +34,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Run tests
-        run: |
-          uv run pytest \
-            -n auto \
-            --cov-report=xml \
-            --cov-config=pyproject.toml \
-            --cov=src \
-            --cov=tests
+        run: uv run pytest -n auto --cov-report=xml --cov-config=pyproject.toml --cov=src --cov=tests
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: Revert these lines if tests succeed.
-        # python-version: ["3.10", "3.11", "3.12"]
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        # NOTE: Test only Python 3.10 on windows environment during pull request.
-        os: [windows-latest]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Tests did not succeed on Windows due to line breaks within the `uv run pytest ...` line.