### PR TITLE
Add type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "scipy>=1.7.2",
   "pillow",
   "imageio",
+  "typing-extensions",
 ]
 
 [project.optional-dependencies]
@@ -111,7 +112,15 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "D203", "D213", "ERA001", "ISC001", "T201"]
+ignore = [
+  "ANN401", # Allow 'Any' type until all arguments are properly typed
+  "COM812",
+  "D203",
+  "D213",
+  "ERA001",
+  "ISC001",
+  "T201",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["D104", "F401"]

--- a/src/imreg_dft/__init__.py
+++ b/src/imreg_dft/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # We may import this during setup invocation
 # because of the version we have to query
 # However, i.e. numpy may not be installed at setup install time.

--- a/src/imreg_dft/show.py
+++ b/src/imreg_dft/show.py
@@ -27,6 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
 
 import argparse as ap
 
@@ -46,7 +47,7 @@ TOSHOW = (
 TOSHOW_ABBR = "isl1a2t"
 
 
-def create_parser():
+def create_parser() -> ap.ArgumentParser:
     parser = ap.ArgumentParser()
     cli.update_parser_imreg(parser)
     parser.add_argument("--prefix", default="reports")
@@ -76,7 +77,7 @@ def create_parser():
     return parser
 
 
-def _show_valid(stri):
+def _show_valid(stri: str) -> str:
     stripped = stri.rstrip(TOSHOW_ABBR)
     if len(stripped) > 0:
         msg = f"Argument contains invalid characters: {stripped}"

--- a/src/imreg_dft/tform.py
+++ b/src/imreg_dft/tform.py
@@ -27,17 +27,22 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
 
 import argparse as ap
 import re
 import sys
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from imreg_dft import cli, imreg, loader, utils
 
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
-def create_parser():
+
+def create_parser() -> ap.ArgumentParser:
     parser = ap.ArgumentParser()
     parser.add_argument("subject")
     parser.add_argument(
@@ -59,7 +64,7 @@ def create_parser():
 
 
 # TODO: Hanldle missing entries + default values
-def _str2tform(tstr):
+def _str2tform(tstr: str) -> dict[str, float | NDArray]:
     """Parses a transformation-descripting string to a transformation dict."""
     rexp = (
         r"scale:\s*(?P<scale>\S*)\s*(\+-\S*)?\s*"
@@ -70,12 +75,13 @@ def _str2tform(tstr):
     match = re.search(rexp, tstr, re.MULTILINE)
     assert match is not None, "No match"
     parsed = match.groupdict()
+    ret: dict[str, float | NDArray]
     ret = {key: float(val) for key, val in parsed.items()}
     ret["tvec"] = np.array((ret["ty"], ret["tx"]))
     return ret
 
 
-def str2tform(tstr, invert=False):
+def str2tform(tstr: str, invert: bool = False) -> dict[str, float | NDArray]:
     try:
         ret = _str2tform(tstr)
     except Exception as e:
@@ -89,7 +95,7 @@ def str2tform(tstr, invert=False):
     return ret
 
 
-def args2dict(args):
+def args2dict(args: ap.Namespace) -> dict[str, Any]:
     """Takes parsed command-line args and makes a dict that contains exact info
     about what needs to be done.
     """

--- a/tests/unittests/tform_test.py
+++ b/tests/unittests/tform_test.py
@@ -14,7 +14,7 @@ from imreg_dft import tform
         "scale: 1.8 angle:186 \nshift (x, y): 35, 44.2 +-0.5 success:1",
     ],
 )
-def test_parse(instr):
+def test_parse(instr: str) -> None:
     res = tform._str2tform(instr)
     assert res["scale"] == pytest.approx(1.8)
     assert res["angle"] == pytest.approx(186)

--- a/tests/unittests/utils_test.py
+++ b/tests/unittests/utils_test.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
-from numpy import fft, int64
+from numpy import fft
 from numpy.testing import (
     assert_almost_equal,
     assert_array_equal,
@@ -28,16 +28,18 @@ def rng() -> Generator:
 
 
 @pytest.fixture
-def size_setup() -> tuple[tuple[int, int], int64]:
+def size_setup() -> tuple[tuple[int, int], int]:
     """Return default array size for tests."""
     whatshape = (20, 11)
     whatsize = np.prod(whatshape)
-    return whatshape, whatsize
+    return whatshape, whatsize.item()
 
 
 @pytest.mark.parametrize("whs", [(20, 11), (21, 12), (22, 13), (50, 60)])
 def test_undo(
-    whs: tuple[int, int], size_setup: tuple[tuple[int, int], int64], rng: Generator
+    whs: tuple[int, int],
+    size_setup: tuple[tuple[int, int], int],
+    rng: Generator,
 ) -> None:
     whatshape, _ = size_setup
     what = rng.random(whatshape)
@@ -51,7 +53,9 @@ def test_undo(
 
 @pytest.mark.parametrize("dst", [2, 3, 4])
 def test_extend(
-    dst: int, size_setup: tuple[tuple[int, int], int64], rng: Generator
+    dst: int,
+    size_setup: tuple[tuple[int, int], int],
+    rng: Generator,
 ) -> None:
     whatshape, whatsize = size_setup
     what = rng.random(whatshape)
@@ -255,7 +259,7 @@ def test_clusters() -> None:
     assert score == scores[0]
 
 
-def __dft_score(arr: NDArray, whatsize: int64) -> float:
+def __dft_score(arr: NDArray, whatsize: int) -> float:
     dft = fft.fft2(arr) * whatsize
     dft /= dft.size
 
@@ -267,7 +271,7 @@ def __dft_score(arr: NDArray, whatsize: int64) -> float:
     return ret.sum()
 
 
-def __wrap_filter(src: NDArray, vecs: list[tuple[float, float]], *args) -> None:
+def __wrap_filter(src: NDArray, vecs: list[tuple[float, float]], *args: Any) -> None:
     dest = src.copy()
     for vec in vecs:
         __add_freq(dest, vec)

--- a/uv.lock
+++ b/uv.lock
@@ -261,6 +261,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "scipy" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -292,6 +293,7 @@ requires-dist = [
     { name = "pillow" },
     { name = "pyfftw", marker = "extra == 'better-performance'" },
     { name = "scipy", specifier = ">=1.7.2" },
+    { name = "typing-extensions" },
 ]
 provides-extras = ["better-performance", "plotting"]
 


### PR DESCRIPTION
This PR adds type hints to all function parameters and return values.

It solves all [ANN rules by ruff](https://docs.astral.sh/ruff/rules/#flake8-2020-ytt), but allows `Any` (ANN401).

The focus of this PR is merely adding type annotations without changing the code itself. Therefore, pyright and mypy still produce errors.